### PR TITLE
update panda to disregard header

### DIFF
--- a/detection-ml-wksp/sec405-ipinsights.ipynb
+++ b/detection-ml-wksp/sec405-ipinsights.ipynb
@@ -236,7 +236,7 @@
     "\n",
     "# Run inference on training (normal) data for sanity check\n",
     "s3_infer_data = 's3://{}/{}'.format(bucket, train_key)\n",
-    "inference_data = pd.read_csv(s3_infer_data)\n",
+    "inference_data = pd.read_csv(s3_infer_data, header=None)\n",
     "inference_data.head()\n",
     "predictor.predict(inference_data.values)"
    ]
@@ -257,7 +257,7 @@
     "# Run inference on GuardDuty findings\n",
     "infer_key = os.path.join(prefix, 'infer', 'guardduty_tuples.csv')\n",
     "s3_infer_data = 's3://{}/{}'.format(bucket, infer_key)\n",
-    "inference_data = pd.read_csv(s3_infer_data)\n",
+    "inference_data = pd.read_csv(s3_infer_data, header=None)\n",
     "inference_data.head()\n",
     "predictor.predict(inference_data.values)"
    ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
inference_data has no header row, so panda should not expect to read it. Otherwise, the last result will have 3 rows, instead of the expected 4 (as there are 4 findings on the guardduty file)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
