### PR TITLE
Removed link to awsmanagementweek.com

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,10 +48,5 @@ The workshops and other hands-on content contained in this portal are focused on
 
 ## Additional resources
 
-Below are some additional resources that have some great hands-on content:
-
-<ul>
-    <li><a href="https://wellarchitectedlabs.com/Security/README.html" target="_blank">AWS Well-Architected Security Labs</a></li>
-    <li><a href="http://www.awsmanagementweek.com/" target="_blank">AWS Management Services Workshops</a></li>
-</ul>
+The <a href="https://wellarchitectedlabs.com/Security/README.html" target="_blank">AWS Well-Architected Security Labs</a> also has some great hands-on content.
 


### PR DESCRIPTION
The domain `awsmanagementweek.com` no longer has any content on it. Updated to remove it from `index.md`.

> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
